### PR TITLE
added convenience method to append attribute with namespaceURI

### DIFF
--- a/src/main/java/com/mycila/xmltool/XMLDoc.java
+++ b/src/main/java/com/mycila/xmltool/XMLDoc.java
@@ -197,6 +197,14 @@ public final class XMLDoc implements XMLTag {
         return this;
     }
 
+    public XMLTag addAttributeNS(String namespaceURI, String name, String value) {
+        if (hasAttribute(name)) {
+            throw new XMLDocumentException("Attribute '%s' already exist on tag '%s'", name, getCurrentTagName());
+        }
+        definition.createAttributeNS(current, namespaceURI, name, value);
+        return this;
+    }
+
     public XMLTag addAttribute(Attr attr) {
         notNull("DOM Attribute", attr);
         if (hasAttribute(attr.getName())) {

--- a/src/main/java/com/mycila/xmltool/XMLDocDefinition.java
+++ b/src/main/java/com/mycila/xmltool/XMLDocDefinition.java
@@ -124,6 +124,15 @@ final class XMLDocDefinition implements NamespaceContext {
         return attr;
     }
 
+    Attr createAttributeNS(Element current, String namespaceURI, String name, String value) {
+        notEmpty("Attribute name", name);
+
+        Attr attr = document.createAttributeNS(namespaceURI, name);
+        attr.setValue(value);
+        current.setAttributeNodeNS(attr);
+        return attr;
+    }
+
     Text createText(String text) {
         notNull("Text", text);
         return document.createTextNode(text);

--- a/src/main/java/com/mycila/xmltool/XMLTag.java
+++ b/src/main/java/com/mycila/xmltool/XMLTag.java
@@ -66,6 +66,16 @@ public interface XMLTag {
     com.mycila.xmltool.XMLTag addAttribute(String name, String value);
 
     /**
+     * Create a new attribute for the current node
+     *
+     * @param namespaceURI  The URI of the namespace, can be <code>null</code>
+     * @param name  Name of the attribute to add
+     * @param value value of the attribute to add
+     * @return this
+     */
+    com.mycila.xmltool.XMLTag addAttributeNS(String namespaceURI, String name, String value);
+
+    /**
      * Add a text node under the current node, and jump to the parent node. This enables the create or quick documents like this:
      * 
      * <code>addTag("name").addText("Bob")addTag("sex").addText("M")addTag("age").addText("30")</code>

--- a/src/test/java/com/mycila/xmltool/XMLDocTest.java
+++ b/src/test/java/com/mycila/xmltool/XMLDocTest.java
@@ -205,6 +205,25 @@ public final class XMLDocTest extends AbstractTest {
     }
 
     @Test
+    public void test_addAttributeNS() throws Exception {
+        XMLTag doc = XMLDoc.newDocument(false).addRoot("html")
+                .addAttribute("lang", "en")
+                .addAttributeNS("http://myns", "fish", "taco")
+                .addTag("body")
+                .addAttribute("onload", "func1")
+                .addAttribute("onclick", "1<2");
+        assertSameDoc(doc.toString(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><html xmlns:ns0=\"http://myns\" ns0:fish=\"taco\" lang=\"en\"><body onclick=\"1&lt;2\" onload=\"func1\"/></html>");
+
+        doc = XMLDoc.newDocument(false).addRoot("html")
+                .addAttribute("lang", "en")
+                .addAttributeNS(null, "fish", "taco")
+                .addTag("body")
+                .addAttribute("onload", "func1")
+                .addAttribute("onclick", "1<2");
+        assertSameDoc(doc.toString(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><html fish=\"taco\" lang=\"en\"><body onclick=\"1&lt;2\" onload=\"func1\"/></html>");
+    }
+
+    @Test
     public void test_addAttribute_existing() throws Exception {
         assertThrow(XMLDocumentException.class).withMessage("Attribute 'onclick' already exist on tag 'body'").whenRunning(new Code() {
             public void run() throws Throwable {
@@ -225,6 +244,13 @@ public final class XMLDocTest extends AbstractTest {
                 .addRoot("html")
                 .addAttribute("lang", "en");
         assertSameDoc(doc.toString(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><html xmlns=\"http://myns\" xmlns:NS1=\"http://myns\" NS1:lang=\"en\"/>");
+
+        doc = XMLDoc.newDocument(false)
+                .addDefaultNamespace("http://myns")
+                .addRoot("html")
+                .addAttributeNS(null, "lang", "en");
+        System.out.println(doc.toString());
+        assertSameDoc(doc.toString(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><html xmlns=\"http://myns\" lang=\"en\"/>");
 
         doc = XMLDoc.newDocument(false)
                 .addDefaultNamespace("http://myns")


### PR DESCRIPTION
... including support for null namespaceURI.

In particular, this solved my problem of trying to create SVG files using xmltool, which typically has the format:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" height="1000" width="1000" />
```

note: the document contains a default namespace, but the attributes are specified without any namespace identifiers.

this can now be created via xmltool:

```
XMLDoc.newDocument(false)
    .addDefaultNamespace("http://www.w3.org/2000/svg")
    .addRoot("svg")
    .addAttributeNS(null, "width", "1000")
    .addAttributeNS(null, "height", "1000")
    .toString();
```
