### PR TITLE
Add pooling for TransformerFactory and XPathFactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ install: /bin/true
 
 jdk:
   - openjdk7
-  - oraclejdk7
+  # No longer supported - see https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+  # - oraclejdk7
 
 branches:
   only:

--- a/src/main/java/com/mycila/xmltool/XMLDoc.java
+++ b/src/main/java/com/mycila/xmltool/XMLDoc.java
@@ -324,8 +324,7 @@ public final class XMLDoc implements XMLTag {
 
     public String getInnerText() {
         try {
-            TransformerFactory tf = TransformerFactory.newInstance();
-            Transformer transformer = tf.newTransformer();
+            Transformer transformer = XMLFactories.createTransformer();
             transformer.setOutputProperty(OutputKeys.ENCODING, definition.getEncoding());
             transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             StringWriter sw = new StringWriter();
@@ -726,12 +725,7 @@ public final class XMLDoc implements XMLTag {
     public XMLTag toResult(Result out, String encoding) {
         notEmpty("encoding", encoding);
         try {
-            TransformerFactory tf = TransformerFactory.newInstance();
-            try {
-                tf.setAttribute("indent-number", 4);
-            } catch (Exception ignored) {
-            }
-            Transformer transformer = tf.newTransformer();
+            Transformer transformer = XMLFactories.createTransformer();
             transformer.setParameter("indent-number", 4);
             transformer.setOutputProperty(OutputKeys.METHOD, "xml");
             transformer.setOutputProperty(OutputKeys.ENCODING, encoding);

--- a/src/main/java/com/mycila/xmltool/XMLDocBuilder.java
+++ b/src/main/java/com/mycila/xmltool/XMLDocBuilder.java
@@ -227,8 +227,7 @@ public final class XMLDocBuilder {
     static XMLTag from(Source source, boolean ignoreNamespaces) {
         DOMResult result = new DOMResult();
         try {
-            TransformerFactory tf = TransformerFactory.newInstance();
-            Transformer transformer = tf.newTransformer();
+            Transformer transformer = XMLFactories.createTransformer();
             transformer.transform(source, result);
         } catch (Exception e) {
             throw new XMLDocumentException("Error creating XMLDoc. Please verify that the input source can be read and is well formed", e);
@@ -239,8 +238,7 @@ public final class XMLDocBuilder {
     static XMLTag from(Source source, boolean ignoreNamespaces, String encoding) {
         DOMResult result = new DOMResult();
         try {
-            TransformerFactory tf = TransformerFactory.newInstance();
-            Transformer transformer = tf.newTransformer();
+            Transformer transformer = XMLFactories.createTransformer();
             transformer.setOutputProperty(OutputKeys.ENCODING, encoding);
             transformer.transform(source, result);
         } catch (Exception e) {

--- a/src/main/java/com/mycila/xmltool/XMLDocPath.java
+++ b/src/main/java/com/mycila/xmltool/XMLDocPath.java
@@ -39,7 +39,7 @@ final class XMLDocPath {
 
     XMLDocPath(XMLDocDefinition context) {
         try {
-            xpath = XPathFactory.newInstance().newXPath();
+            xpath = XMLFactories.createXPath();
             xpath.setNamespaceContext(context);
         }
         catch (Exception e) {

--- a/src/main/java/com/mycila/xmltool/XMLFactories.java
+++ b/src/main/java/com/mycila/xmltool/XMLFactories.java
@@ -1,0 +1,81 @@
+package com.mycila.xmltool;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+public class XMLFactories {
+    private static ObjectPool<TransformerFactory> transformerFactoryPool;
+    private static ObjectPool<XPathFactory> xpathFactoryPool;
+
+    static {
+        GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+        config.setMinIdle(0);
+        config.setMaxIdle(Runtime.getRuntime().availableProcessors());
+        config.setMaxTotal(Runtime.getRuntime().availableProcessors() * 4);
+        config.setMaxWaitMillis(-1);
+
+        setPoolConfig(config);
+    }
+
+    public static void setPoolConfig(GenericObjectPoolConfig config) {
+        transformerFactoryPool = new GenericObjectPool<TransformerFactory>(
+            new BasePooledObjectFactory<TransformerFactory>() {
+                @Override
+                public TransformerFactory create() throws Exception {
+                    return TransformerFactory.newInstance();
+                }
+
+                @Override
+                public PooledObject<TransformerFactory> wrap(TransformerFactory obj) {
+                    return new DefaultPooledObject<TransformerFactory>(obj);
+                }
+            }, config);
+        xpathFactoryPool = new GenericObjectPool<XPathFactory>(new BasePooledObjectFactory<XPathFactory>() {
+            @Override
+            public XPathFactory create() throws Exception {
+                return XPathFactory.newInstance();
+            }
+
+            @Override
+            public PooledObject<XPathFactory> wrap(XPathFactory obj) {
+                return new DefaultPooledObject<XPathFactory>(obj);
+            }
+        }, config);
+    }
+
+    public static Transformer createTransformer() throws TransformerConfigurationException {
+        try {
+            TransformerFactory factory = transformerFactoryPool.borrowObject();
+            try {
+                return factory.newTransformer();
+            } finally {
+                transformerFactoryPool.returnObject(factory);
+            }
+        } catch (Exception e) {
+            throw new TransformerConfigurationException("Failed to borrow transformer factory", e);
+        }
+    }
+
+    public static XPath createXPath() {
+        try {
+            XPathFactory factory = xpathFactoryPool.borrowObject();
+            try {
+                return factory.newXPath();
+            } finally {
+                xpathFactoryPool.returnObject(factory);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to borrow XPath factory", e);
+        }
+    }
+}

--- a/src/main/java/com/mycila/xmltool/XMLFactories.java
+++ b/src/main/java/com/mycila/xmltool/XMLFactories.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mycila.xmltool;
 
 import javax.xml.transform.Transformer;
@@ -27,7 +42,7 @@ public class XMLFactories {
         setPoolConfig(config);
     }
 
-    public static void setPoolConfig(GenericObjectPoolConfig config) {
+    public static void setPoolConfig(final GenericObjectPoolConfig config) {
         transformerFactoryPool = new GenericObjectPool<TransformerFactory>(
             new BasePooledObjectFactory<TransformerFactory>() {
                 @Override
@@ -36,7 +51,7 @@ public class XMLFactories {
                 }
 
                 @Override
-                public PooledObject<TransformerFactory> wrap(TransformerFactory obj) {
+                public PooledObject<TransformerFactory> wrap(final TransformerFactory obj) {
                     return new DefaultPooledObject<TransformerFactory>(obj);
                 }
             }, config);
@@ -47,7 +62,7 @@ public class XMLFactories {
             }
 
             @Override
-            public PooledObject<XPathFactory> wrap(XPathFactory obj) {
+            public PooledObject<XPathFactory> wrap(final XPathFactory obj) {
                 return new DefaultPooledObject<XPathFactory>(obj);
             }
         }, config);

--- a/src/test/java/com/mycila/xmltool/AbstractTest.java
+++ b/src/test/java/com/mycila/xmltool/AbstractTest.java
@@ -15,13 +15,15 @@
  */
 package com.mycila.xmltool;
 
-import org.junit.Assert;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
 
 /**
  * @author Mathieu Carbou (mathieu.carbou@gmail.com)
@@ -31,7 +33,13 @@ public abstract class AbstractTest {
     private static final SoftHashMap<URL, byte[]> cache = new SoftHashMap<URL, byte[]>();
     private static final byte[] NULL = new byte[0];
 
-    protected void assertSameDoc(String actual, String expected) {
+    @BeforeClass
+    public static void setLocaleToEN_US() {
+      // needed to make tests pass on non-EN/US systems due to localized exception messsages
+      Locale.setDefault(Locale.US);
+    }
+    
+    protected void assertSameDoc(final String actual, final String expected) {
         Assert.assertEquals(actual.replaceAll("\\r|\\n", "").replaceAll(">\\s*<", "><"), expected.replaceAll("\\r|\\n", "").replaceAll(">\\s*<", "><"));
     }
 


### PR DESCRIPTION
As mentioned in your #15 (and partially addressed in #16) the XML factories have huge performance issues. As the factories cannot be presumed to be thread-safe they either must be pooled, held in a `ThreadLocal` or synchronized. In this pull request I have opted to follow your pattern of using commons pools in order to pool those resources.
The implementation uses a separate `XMLFactory` class for both the `XPathFactory`-pool as well as the `TransformerFactory`-pool. On could argue that it would make sense to move the `DocumentBuilders` over there as well, but that would have broken the API.